### PR TITLE
[LSAC-019] feat(llm): 클라이언트는 서버로부터 개발 서비스 도메인에 대한 LLM 스트리밍 서비스를 제공받을 수 있다

### DIFF
--- a/src/main/java/personal/llmapiclient/client/LLMStreamingClient.java
+++ b/src/main/java/personal/llmapiclient/client/LLMStreamingClient.java
@@ -1,0 +1,53 @@
+package personal.llmapiclient.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import personal.llmapiclient.requestdto.AbstractOptionsRequest;
+import personal.llmapiclient.requestdto.LLMRequest;
+import reactor.core.publisher.Flux;
+
+@Component
+public class LLMStreamingClient {
+    private final WebClient webClient;
+    private static final String LLM_SERVER_URL = "https://hyobin-llm.duckdns.org";
+
+    public LLMStreamingClient() {
+        webClient = WebClient.create(LLM_SERVER_URL);
+    }
+
+    @Value("${llm.type}")
+    private String llmType;
+
+    @Value("${llm.server.secret-key}")
+    private String secretKey;
+
+    @Value("${llm.server.endpoint.streaming}")
+    private String streamingRequestEndpoint;
+
+    @Value("${llm.server.endpoint.sse}")
+    private String sseRequestEndpoint;
+
+    public Flux<String> receiveLLMStreaming(AbstractOptionsRequest optionsRequest, String template) {
+        LLMRequest llmRequest = LLMRequest.from(llmType, template, optionsRequest, secretKey);
+
+        return webClientRequest(streamingRequestEndpoint, llmRequest);
+    }
+
+    public Flux<String> receiveLLMStreamingSSE(AbstractOptionsRequest optionsRequest, String template) {
+        LLMRequest llmRequest = LLMRequest.from(llmType, template, optionsRequest, secretKey);
+
+        return webClientRequest(sseRequestEndpoint, llmRequest);
+    }
+
+    private Flux<String> webClientRequest(String requestEndpoint, LLMRequest llmRequest) {
+        return webClient.post()
+                .uri(requestEndpoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .bodyValue(llmRequest)
+                .retrieve()
+                .bodyToFlux(String.class);
+    }
+}

--- a/src/main/java/personal/llmapiclient/controller/LLMController.java
+++ b/src/main/java/personal/llmapiclient/controller/LLMController.java
@@ -1,0 +1,84 @@
+package personal.llmapiclient.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import personal.llmapiclient.client.LLMStreamingClient;
+import personal.llmapiclient.requestdto.DefaultOptionsRequest;
+import personal.llmapiclient.util.ResponseGenerator;
+import personal.llmapiclient.util.StreamingProcessor;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class LLMController {
+    private final LLMStreamingClient llmStreamingClient;
+
+    @Value("${llm.template}")
+    private String template;
+
+    private static final String GET_LLM_STREAMING = "LLM API를 통해 특정 도메인 LLM 서비스 이용";
+    private static final String GET_LLM_STREAMING_DESCRIPTION
+            = "LLM API를 통해 특정 도메인 LLM 서비스를 이용할 수 있습니다.";
+
+    private static final String GET_LLM_STREAMING_SSE = "LLM API를 통해 특정 도메인 LLM SSE 서비스 이용";
+    private static final String GET_LLM_STREAMING_SSE_DESCRIPTION
+            = "LLM API를 통해 특정 도메인 LLM SSE 서비스를 이용할 수 있습니다.";
+
+    private static final String OPTION_ONE = "첫 번째 옵션";
+    private static final String OPTION_ONE_EXAMPLE = "옵션1, 옵션2, 옵션3";
+
+    private static final String OPTION_TWO = "두 번째 옵션";
+    private static final String OPTION_TWO_EXAMPLE = "옵션1, 옵션2";
+
+    private static final String OPTION_THREE = "세 번째 옵션";
+    private static final String OPTION_THREE_EXAMPLE = "옵션1, 옵션2, 옵션3, 옵션4";
+
+    @ApiOperation(value = GET_LLM_STREAMING, notes = GET_LLM_STREAMING_DESCRIPTION)
+    @GetMapping(value = "/template", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestLLM(
+            @ApiParam(value = OPTION_ONE, defaultValue = OPTION_ONE_EXAMPLE)
+            @RequestParam List<String> option1,
+            @ApiParam(value = OPTION_TWO, defaultValue = OPTION_TWO_EXAMPLE)
+            @RequestParam List<String> option2,
+            @ApiParam(value = OPTION_THREE, defaultValue = OPTION_THREE_EXAMPLE)
+            @RequestParam List<String> option3
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreaming(
+                DefaultOptionsRequest.of(option1, option2, option3), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+
+    @ApiOperation(value = GET_LLM_STREAMING_SSE, notes = GET_LLM_STREAMING_SSE_DESCRIPTION)
+    @GetMapping(value = "/template/sse", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestSSELLM(
+            @ApiParam(value = OPTION_ONE, defaultValue = OPTION_ONE_EXAMPLE)
+            @RequestParam List<String> option1,
+            @ApiParam(value = OPTION_TWO, defaultValue = OPTION_TWO_EXAMPLE)
+            @RequestParam List<String> option2,
+            @ApiParam(value = OPTION_THREE, defaultValue = OPTION_THREE_EXAMPLE)
+            @RequestParam List<String> option3
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreamingSSE(
+                DefaultOptionsRequest.of(option1, option2, option3), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+}

--- a/src/main/java/personal/llmapiclient/controller/LLMExampleController.java
+++ b/src/main/java/personal/llmapiclient/controller/LLMExampleController.java
@@ -1,0 +1,102 @@
+package personal.llmapiclient.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import personal.llmapiclient.client.LLMStreamingClient;
+import personal.llmapiclient.requestdto.RecipeOptionsRequest;
+import personal.llmapiclient.util.ResponseGenerator;
+import personal.llmapiclient.util.StreamingProcessor;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class LLMExampleController {
+    private final LLMStreamingClient llmStreamingClient;
+
+    @Value("${llm.recipe.template}")
+    private String template;
+
+    private static final String GET_RECIPE_LLM_STREAMING = "LLM API를 통해 레시피 정보를 조회하는 예시";
+    private static final String GET_RECIPE_LLM_STREAMING_DESCRIPTION
+            = "LLM API를 통해 레시피 정보를 조회할 수 있습니다.";
+
+    private static final String GET_RECIPE_LLM_SSE_STREAMING = "LLM API를 통해 SSE 방식으로 레시피 정보를 조회하는 예시";
+    private static final String GET_RECIPE_LLM_SSE_STREAMING_DESCRIPTION
+            = "LLM API를 통해 SSE 방식으로 레시피 정보를 조회할 수 있습니다.";
+
+    private static final String MEAL_TYPE = "식사 유형";
+    private static final String MEAL_TYPE_EXAMPLE = "아침";
+
+    private static final String CUISINETYPE = "요리 유형";
+    private static final String CUISINETYPE_EXAMPLE = "한식";
+
+    private static final String INGREDIENTS = "재료 목록";
+    private static final String INGREDIENTS_EXAMPLE = "된장, 파, 마늘";
+
+    private static final String COOKING_UTENSILS = "조리 도구";
+    private static final String COOKING_UTENSILS_EXAMPLE = "프라이팬, 냄비, 식칼";
+
+    private static final String COOKING_TIME = "조리 시간";
+    private static final String COOKING_TIME_EXAMPLE = "30분";
+
+    @ApiOperation(
+            value = GET_RECIPE_LLM_STREAMING, notes = GET_RECIPE_LLM_STREAMING_DESCRIPTION
+    )
+    @GetMapping(value = "/example", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestRecipeLLM(
+            @ApiParam(value = MEAL_TYPE, example = MEAL_TYPE_EXAMPLE)
+            @RequestParam String mealType,
+            @ApiParam(value = CUISINETYPE, example = CUISINETYPE_EXAMPLE)
+            @RequestParam String cuisineType,
+            @ApiParam(value = INGREDIENTS, defaultValue = INGREDIENTS_EXAMPLE)
+            @RequestParam List<String> ingredients,
+            @ApiParam(value = COOKING_UTENSILS, defaultValue = COOKING_UTENSILS_EXAMPLE)
+            @RequestParam List<String> cookingUtensils,
+            @ApiParam(value = COOKING_TIME, example = COOKING_TIME_EXAMPLE)
+            @RequestParam String cookingTime
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreaming(
+                RecipeOptionsRequest.of(mealType, cuisineType, ingredients, cookingUtensils, cookingTime), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+
+    @ApiOperation(
+            value = GET_RECIPE_LLM_SSE_STREAMING, notes = GET_RECIPE_LLM_SSE_STREAMING_DESCRIPTION
+    )
+    @GetMapping(value = "/example/sse", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestRecipeSSELLM(
+            @ApiParam(value = MEAL_TYPE, example = MEAL_TYPE_EXAMPLE)
+            @RequestParam String mealType,
+            @ApiParam(value = CUISINETYPE, example = CUISINETYPE_EXAMPLE)
+            @RequestParam String cuisineType,
+            @ApiParam(value = INGREDIENTS, defaultValue = INGREDIENTS_EXAMPLE)
+            @RequestParam List<String> ingredients,
+            @ApiParam(value = COOKING_UTENSILS, defaultValue = COOKING_UTENSILS_EXAMPLE)
+            @RequestParam List<String> cookingUtensils,
+            @ApiParam(value = COOKING_TIME, example = COOKING_TIME_EXAMPLE)
+            @RequestParam String cookingTime
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreamingSSE(
+                RecipeOptionsRequest.of(mealType, cuisineType, ingredients, cookingUtensils, cookingTime), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+}

--- a/src/main/java/personal/llmapiclient/exception/ErrorResponse.java
+++ b/src/main/java/personal/llmapiclient/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package personal.llmapiclient.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ErrorResponse {
+    private int statusCode;
+    private String message;
+}

--- a/src/main/java/personal/llmapiclient/requestdto/AbstractOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/AbstractOptionsRequest.java
@@ -1,0 +1,4 @@
+package personal.llmapiclient.requestdto;
+
+public abstract class AbstractOptionsRequest {
+}

--- a/src/main/java/personal/llmapiclient/requestdto/DefaultOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/DefaultOptionsRequest.java
@@ -1,0 +1,28 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class DefaultOptionsRequest extends AbstractOptionsRequest {
+    private List<String> option1;
+    private List<String> option2;
+    private List<String> option3;
+
+    @Builder
+    private DefaultOptionsRequest(List<String> option1, List<String> option2, List<String> option3) {
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+    }
+
+    public static DefaultOptionsRequest of(List<String> option1, List<String> option2, List<String> option3) {
+        return new DefaultOptionsRequest(option1, option2, option3);
+    }
+}

--- a/src/main/java/personal/llmapiclient/requestdto/LLMRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/LLMRequest.java
@@ -1,0 +1,24 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Getter;
+
+@Getter
+public class LLMRequest {
+    private String llm_type;
+    private String template;
+    private AbstractOptionsRequest options;
+    private String secret_key;
+
+    private LLMRequest(String llm_type, String template, AbstractOptionsRequest optionsRequest, String secret_key) {
+        this.llm_type = llm_type;
+        this.template = template;
+        options = optionsRequest;
+        this.secret_key = secret_key;
+    }
+
+    public static LLMRequest from(
+            String llm_type, String template, AbstractOptionsRequest optionsRequest, String secret_key
+    ) {
+        return new LLMRequest(llm_type, template, optionsRequest, secret_key);
+    }
+}

--- a/src/main/java/personal/llmapiclient/requestdto/RecipeOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/RecipeOptionsRequest.java
@@ -1,0 +1,35 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeOptionsRequest extends AbstractOptionsRequest {
+    private List<String> mealType;
+    private List<String> cuisineType;
+    private List<String> ingredients;
+    private List<String> cookingUtensils;
+    private List<String> cookingTime;
+
+
+    private RecipeOptionsRequest(
+            List<String> mealType, List<String> cuisineType, List<String> ingredients,
+            List<String> cookingUtensils, List<String> cookingTime
+    ) {
+        this.mealType = mealType;
+        this.cuisineType = cuisineType;
+        this.ingredients = ingredients;
+        this.cookingUtensils = cookingUtensils;
+        this.cookingTime = cookingTime;
+    }
+
+    public static RecipeOptionsRequest of(
+            String mealType, String cuisineType, List<String> ingredients,
+            List<String> cookingUtensils, String cookingTime
+    ) {
+        return new RecipeOptionsRequest(
+                List.of(mealType), List.of(cuisineType), ingredients, cookingUtensils, List.of(cookingTime)
+        );
+    }
+}

--- a/src/main/java/personal/llmapiclient/util/ResponseGenerator.java
+++ b/src/main/java/personal/llmapiclient/util/ResponseGenerator.java
@@ -1,0 +1,13 @@
+package personal.llmapiclient.util;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+
+public class ResponseGenerator {
+    public static ResponseEntity<Flux<String>> generateResponse(Flux<String> responseFlux) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(responseFlux.flatMap(chunk -> Flux.just(chunk + "\n\n")));
+    }
+}

--- a/src/main/java/personal/llmapiclient/util/StreamingProcessor.java
+++ b/src/main/java/personal/llmapiclient/util/StreamingProcessor.java
@@ -1,0 +1,24 @@
+package personal.llmapiclient.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StreamingProcessor {
+    private static final Logger log = LoggerFactory.getLogger(StreamingProcessor.class);
+
+    public static void proceedStreaming(Flux<String> responseFlux) {
+        AtomicInteger counter = new AtomicInteger(0);
+        responseFlux.subscribe(
+                chunk -> {
+                    if (counter.incrementAndGet() % 10 == 0) {
+                        log.info("Received chunk: {}", chunk);
+                    }
+                },
+                error -> log.error(LogConstant.LOG_ERROR_MESSAGE, error.getMessage(), error),
+                () -> log.info("Streaming finished.")
+        );
+    }
+}


### PR DESCRIPTION
## resolve [LSAC-019](https://langchain.atlassian.net/browse/LSAC-19)
## resolve #9

## 작업내용
- 기존에 구현한 LLM Streaming 서버로 Prompt 요청을 전송해 응답을 제공받는 클라이언트 컴포넌트 추가
- 특정 Prompt에 대한 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가
- 특정 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가
- 레시피 추천 요청 Prompt에 대한 Steraming 응답을 제공받을 수 있는 예시 엔드포인트 추가
- 레시피 추천 요청 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 레시피 추천 예시 엔드포인트 추가