### PR TITLE
[LSAC-001] release: LLM API 클라이언트 서버 템플릿 구현 (LlmStreamingApiClientRelease02/02)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+application-local.yml
+
+logs/**
+
+test
+dev/**
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### git ###
+.gitattributes
+
+### Tiled ###
+*~

--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# ![llm](https://github.com/user-attachments/assets/b66e143c-0f7d-4f09-97a6-04a484767025) Spring  WebFlux 기반 생성형 AI  Streaming API Client 템플릿<br><br>
+
+## 📋 프로젝트 설명
+- LLM Streaming Server를 통해 Spring 기반 서비스에서 LLM 스트리밍 서비스를 제공하는 API 클라이언트 템플릿
+- 기본 템플릿과 예시 제공
+
+## 📅 프로젝트 기간
+<b>2025. 02. 02</b>
+<br><br>
+
+## 👫 구성원
+
+### 성효빈
+- 서버 개발, 배포 및 관리
+  <br>
+
+## 📚 관련 URL
+- [서버 API](https://hyobin-llm-client.duckdns.org/swagger-ui/index.html)
+  <br><br>
+
+## 🛠️ Skills
+
+## Back-End
+- Java 11
+- Spring Boot
+- Spring WebFlux
+- Spring Security
+  <br>
+
+## DevOps
+
+### Build
+- Gradle
+
+### WAS
+- Tomcat
+
+### Server
+- AWS EC2
+  <br>
+
+## Tools
+
+### IDE
+- IntelliJ
+
+### Issue Tracking
+- Jira
+
+<br>
+
+## 릴리스 정보 - LLM Streaming API Client - LlmStreamingApiClientRelease02/02
+
+### 하위 작업
+
+[LSAC-3](https://langchain.atlassian.net/browse/LSAC-3) gradle 의존성 추가
+
+[LSAC-4](https://langchain.atlassian.net/browse/LSAC-4) production application 설정 추가
+
+[LSAC-5](https://langchain.atlassian.net/browse/LSAC-5) production application 클래스 추가
+
+[LSAC-6](https://langchain.atlassian.net/browse/LSAC-6) gitignore 추가
+
+[LSAC-8](https://langchain.atlassian.net/browse/LSAC-8) 로깅 설정 파일 추가
+
+[LSAC-9](https://langchain.atlassian.net/browse/LSAC-9) LoggingInterceptor 추가
+
+[LSAC-10](https://langchain.atlassian.net/browse/LSAC-10) LoggingAspect 추가
+
+[LSAC-12](https://langchain.atlassian.net/browse/LSAC-12) 인증을 위한 필터 설정
+
+[LSAC-13](https://langchain.atlassian.net/browse/LSAC-13) JWT 토큰 설정
+
+[LSAC-14](https://langchain.atlassian.net/browse/LSAC-14) 인증 없이 요청 가능한 엔드포인트 허용 설정
+
+[LSAC-15](https://langchain.atlassian.net/browse/LSAC-15) 특정 출처에 대한 CORS 활성화
+
+[LSAC-17](https://langchain.atlassian.net/browse/LSAC-17) springfox 의존성 추가
+
+[LSAC-18](https://langchain.atlassian.net/browse/LSAC-18) Swagger 설정 추가
+
+[LSAC-20](https://langchain.atlassian.net/browse/LSAC-20) 기존에 구현한 LLM Streaming 서버로 Prompt 요청을 전송해 응답을 제공받는 클라이언트 컴포넌트 추가
+
+[LSAC-21](https://langchain.atlassian.net/browse/LSAC-21) 특정 Prompt에 대한 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가
+
+[LSAC-22](https://langchain.atlassian.net/browse/LSAC-22) 특정 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가
+
+[LSAC-23](https://langchain.atlassian.net/browse/LSAC-23) 레시피 추천 요청 Prompt에 대한 Steraming 응답을 제공받을 수 있는 예시 엔드포인트 추가
+
+[LSAC-24](https://langchain.atlassian.net/browse/LSAC-24) 레시피 추천 요청 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 레시피 추천 예시 엔드포인트 추가
+
+### 에픽
+
+[LSAC-1](https://langchain.atlassian.net/browse/LSAC-1) LLM API 클라이언트 서버 템플릿 구현
+
+### 스토리
+
+[LSAC-19](https://langchain.atlassian.net/browse/LSAC-19) 클라이언트는 서버로부터 개발 서비스 도메인에 대한 LLM 스트리밍 서비스를 제공받을 수 있다
+
+### 작업
+
+[LSAC-2](https://langchain.atlassian.net/browse/LSAC-2) 프로젝트 환경 설정
+
+[LSAC-7](https://langchain.atlassian.net/browse/LSAC-7) 전체 프로젝트의 로깅 프로세스 추가
+
+[LSAC-11](https://langchain.atlassian.net/browse/LSAC-11) Spring Security 설정 추가
+
+[LSAC-16](https://langchain.atlassian.net/browse/LSAC-16) 서버 API 문서화를 위한 Swagger 추가
+
+[LSAC-25](https://langchain.atlassian.net/browse/LSAC-25) README.md 추가

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,75 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '2.7.18'
+    id 'io.spring.dependency-management' version '1.1.6'
+}
+
+group = 'personal'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.12'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
+
+    // json
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.json:json:20220924'
+    implementation 'org.apache.commons:commons-text:1.10.0'
+
+    // springfox
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+    // streaming
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security:2.7.8'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // aspect
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // health check
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // netty resolver
+    implementation 'io.netty:netty-resolver-dns:4.1.94.Final'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+task printProjectName {
+    doLast {
+        println project.name
+    }
+}
+
+task printProjectVersion {
+    doLast {
+        println version
+    }
+}
+
+jar {
+    enabled = false
+}

--- a/src/main/java/personal/llmapiclient/LlmApiClientApplication.java
+++ b/src/main/java/personal/llmapiclient/LlmApiClientApplication.java
@@ -1,0 +1,11 @@
+package personal.llmapiclient;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LlmApiClientApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(LlmApiClientApplication.class, args);
+    }
+}

--- a/src/main/java/personal/llmapiclient/aop/LoggingAspect.java
+++ b/src/main/java/personal/llmapiclient/aop/LoggingAspect.java
@@ -1,0 +1,72 @@
+package personal.llmapiclient.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import personal.llmapiclient.util.PerformanceMeasurer;
+
+import static personal.llmapiclient.util.LogConstant.PERFORMANCE_MEASUREMENT;
+
+
+@Component
+@Aspect
+public class LoggingAspect {
+    private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
+
+    private static final String SERVICE_LOGGING_EXECUTION_POINTCUT
+            = "execution(* com.example.samplespringproject..service.*.*(..))";
+    private static final String CLIENT_LOGGING_EXECUTION_POINTCUT
+            = "execution(* com.example.samplespringproject..client.*.*(..))";
+
+    private static final String START
+            = "Beginning to '{}.{}' task with parameters: {}";
+    private static final String END
+            = "'{}.{}' task was executed successfully by {}: '{}', ";
+
+    @Around(SERVICE_LOGGING_EXECUTION_POINTCUT)
+    public Object serviceLogAroundForStringValue(ProceedingJoinPoint joinPoint) throws Throwable {
+        return performLogging(joinPoint);
+    }
+
+    @Around(CLIENT_LOGGING_EXECUTION_POINTCUT)
+    public Object clientLogAroundForStringValue(ProceedingJoinPoint joinPoint) throws Throwable {
+        return performLogging(joinPoint);
+    }
+
+    private Object performLogging(ProceedingJoinPoint joinPoint) throws Throwable {
+        String methodName = joinPoint.getSignature().getName();
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+
+        String[] parameterNames = ((CodeSignature) joinPoint.getSignature()).getParameterNames();
+        Object[] parameterValues = joinPoint.getArgs();
+
+        StringBuilder params = new StringBuilder();
+        for (int i = 0; i < parameterNames.length; i++) {
+            if (i > 0) {
+                params.append(", ");
+            }
+            params.append(parameterNames[i]).append(": ").append(parameterValues[i]);
+        }
+
+        log.info(START, className, methodName, params.toString());
+
+        long beforeMemory = PerformanceMeasurer.computeUsedMemory(0);
+        long startedAt = PerformanceMeasurer.computeElapsedTime(0);
+
+        Object process = joinPoint.proceed();
+
+        long elapsedTime = PerformanceMeasurer.computeElapsedTime(startedAt);
+        long memoryUsage = PerformanceMeasurer.computeUsedMemory(beforeMemory);
+
+        log.info(END + PERFORMANCE_MEASUREMENT,
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(), className, methodName,
+                elapsedTime, memoryUsage);
+
+        return process;
+    }
+}

--- a/src/main/java/personal/llmapiclient/client/LLMStreamingClient.java
+++ b/src/main/java/personal/llmapiclient/client/LLMStreamingClient.java
@@ -1,0 +1,53 @@
+package personal.llmapiclient.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import personal.llmapiclient.requestdto.AbstractOptionsRequest;
+import personal.llmapiclient.requestdto.LLMRequest;
+import reactor.core.publisher.Flux;
+
+@Component
+public class LLMStreamingClient {
+    private final WebClient webClient;
+    private static final String LLM_SERVER_URL = "https://hyobin-llm.duckdns.org";
+
+    public LLMStreamingClient() {
+        webClient = WebClient.create(LLM_SERVER_URL);
+    }
+
+    @Value("${llm.type}")
+    private String llmType;
+
+    @Value("${llm.server.secret-key}")
+    private String secretKey;
+
+    @Value("${llm.server.endpoint.streaming}")
+    private String streamingRequestEndpoint;
+
+    @Value("${llm.server.endpoint.sse}")
+    private String sseRequestEndpoint;
+
+    public Flux<String> receiveLLMStreaming(AbstractOptionsRequest optionsRequest, String template) {
+        LLMRequest llmRequest = LLMRequest.from(llmType, template, optionsRequest, secretKey);
+
+        return webClientRequest(streamingRequestEndpoint, llmRequest);
+    }
+
+    public Flux<String> receiveLLMStreamingSSE(AbstractOptionsRequest optionsRequest, String template) {
+        LLMRequest llmRequest = LLMRequest.from(llmType, template, optionsRequest, secretKey);
+
+        return webClientRequest(sseRequestEndpoint, llmRequest);
+    }
+
+    private Flux<String> webClientRequest(String requestEndpoint, LLMRequest llmRequest) {
+        return webClient.post()
+                .uri(requestEndpoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .bodyValue(llmRequest)
+                .retrieve()
+                .bodyToFlux(String.class);
+    }
+}

--- a/src/main/java/personal/llmapiclient/configuration/InterceptorConfig.java
+++ b/src/main/java/personal/llmapiclient/configuration/InterceptorConfig.java
@@ -1,0 +1,14 @@
+package personal.llmapiclient.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import personal.llmapiclient.interception.LoggingInterceptor;
+
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoggingInterceptor());
+    }
+}

--- a/src/main/java/personal/llmapiclient/configuration/SwaggerConfig.java
+++ b/src/main/java/personal/llmapiclient/configuration/SwaggerConfig.java
@@ -1,0 +1,113 @@
+package personal.llmapiclient.configuration;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.*;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static personal.llmapiclient.util.RequestConstant.*;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    private static final String GROUP_NAME = "llm-api-client";
+    private static final String BASE_PACKAGE = "personal.llmapiclient";
+    private static final String TITLE = "LLM Streaming API Client Template";
+    private static final String DESCRIPTION = "Spring Framework 환경에서 LLM Streaming 서비스를 구현할 수 있는 API Client 템플릿입니다.";
+    private static final String VERSION = "1.0";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName(GROUP_NAME)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage(BASE_PACKAGE))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo())
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()));
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .forPaths(PathSelectors.any())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[0];
+        return Arrays.asList(new SecurityReference(JWT, authorizationScopes));
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey(JWT, AUTHORIZATION, HEADER);
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .version(VERSION)
+                .build();
+    }
+
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping
+            (WebEndpointsSupplier webEndpointsSupplier, ServletEndpointsSupplier servletEndpointsSupplier,
+             ControllerEndpointsSupplier controllerEndpointsSupplier, EndpointMediaTypes endpointMediaTypes,
+             CorsEndpointProperties corsProperties, WebEndpointProperties webEndpointProperties,
+             Environment environment) {
+
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+
+        boolean shouldRegisterLinksMapping
+                = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
+
+        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
+                corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath),
+                shouldRegisterLinksMapping, null);
+
+    }
+
+    private boolean shouldRegisterLinksMapping
+            (WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled()
+                && (
+                StringUtils.hasText(basePath)
+                        || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT)
+        );
+    }
+}

--- a/src/main/java/personal/llmapiclient/configuration/WebConfig.java
+++ b/src/main/java/personal/llmapiclient/configuration/WebConfig.java
@@ -1,0 +1,21 @@
+package personal.llmapiclient.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+                .allowedOriginPatterns(frontendUrl)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/personal/llmapiclient/configuration/WebSecurityConfig.java
+++ b/src/main/java/personal/llmapiclient/configuration/WebSecurityConfig.java
@@ -1,0 +1,59 @@
+package personal.llmapiclient.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import personal.llmapiclient.filtration.JwtAuthenticationFilter;
+import personal.llmapiclient.security.CustomAuthenticationEntryPoint;
+import personal.llmapiclient.security.JwtTokenProvider;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class WebSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint) // 인증되지 않았을 시 custom entry point 사용
+                .and()
+                .httpBasic().disable() // JWT 사용
+                .cors()
+                .and()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers("/swagger-ui/**", "/v2/api-docs", "/swagger-resources/**",
+                        "/**/signup", "/**/login", "/users", "/token",
+                        "/template", "/template/sse", "/example", "/example/sse")
+                .permitAll()
+                .antMatchers(HttpMethod.GET, "/users/{userId}").permitAll()
+                .antMatchers(HttpMethod.GET, "/products/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/reviews/products/{productId}").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter
+                                (jwtTokenProvider, customAuthenticationEntryPoint),
+                        UsernamePasswordAuthenticationFilter.class)
+                .logout().permitAll();
+
+        return http.build();
+    }
+}

--- a/src/main/java/personal/llmapiclient/controller/LLMController.java
+++ b/src/main/java/personal/llmapiclient/controller/LLMController.java
@@ -1,0 +1,84 @@
+package personal.llmapiclient.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import personal.llmapiclient.client.LLMStreamingClient;
+import personal.llmapiclient.requestdto.DefaultOptionsRequest;
+import personal.llmapiclient.util.ResponseGenerator;
+import personal.llmapiclient.util.StreamingProcessor;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class LLMController {
+    private final LLMStreamingClient llmStreamingClient;
+
+    @Value("${llm.template}")
+    private String template;
+
+    private static final String GET_LLM_STREAMING = "LLM API를 통해 특정 도메인 LLM 서비스 이용";
+    private static final String GET_LLM_STREAMING_DESCRIPTION
+            = "LLM API를 통해 특정 도메인 LLM 서비스를 이용할 수 있습니다.";
+
+    private static final String GET_LLM_STREAMING_SSE = "LLM API를 통해 특정 도메인 LLM SSE 서비스 이용";
+    private static final String GET_LLM_STREAMING_SSE_DESCRIPTION
+            = "LLM API를 통해 특정 도메인 LLM SSE 서비스를 이용할 수 있습니다.";
+
+    private static final String OPTION_ONE = "첫 번째 옵션";
+    private static final String OPTION_ONE_EXAMPLE = "옵션1, 옵션2, 옵션3";
+
+    private static final String OPTION_TWO = "두 번째 옵션";
+    private static final String OPTION_TWO_EXAMPLE = "옵션1, 옵션2";
+
+    private static final String OPTION_THREE = "세 번째 옵션";
+    private static final String OPTION_THREE_EXAMPLE = "옵션1, 옵션2, 옵션3, 옵션4";
+
+    @ApiOperation(value = GET_LLM_STREAMING, notes = GET_LLM_STREAMING_DESCRIPTION)
+    @GetMapping(value = "/template", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestLLM(
+            @ApiParam(value = OPTION_ONE, defaultValue = OPTION_ONE_EXAMPLE)
+            @RequestParam List<String> option1,
+            @ApiParam(value = OPTION_TWO, defaultValue = OPTION_TWO_EXAMPLE)
+            @RequestParam List<String> option2,
+            @ApiParam(value = OPTION_THREE, defaultValue = OPTION_THREE_EXAMPLE)
+            @RequestParam List<String> option3
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreaming(
+                DefaultOptionsRequest.of(option1, option2, option3), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+
+    @ApiOperation(value = GET_LLM_STREAMING_SSE, notes = GET_LLM_STREAMING_SSE_DESCRIPTION)
+    @GetMapping(value = "/template/sse", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestSSELLM(
+            @ApiParam(value = OPTION_ONE, defaultValue = OPTION_ONE_EXAMPLE)
+            @RequestParam List<String> option1,
+            @ApiParam(value = OPTION_TWO, defaultValue = OPTION_TWO_EXAMPLE)
+            @RequestParam List<String> option2,
+            @ApiParam(value = OPTION_THREE, defaultValue = OPTION_THREE_EXAMPLE)
+            @RequestParam List<String> option3
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreamingSSE(
+                DefaultOptionsRequest.of(option1, option2, option3), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+}

--- a/src/main/java/personal/llmapiclient/controller/LLMExampleController.java
+++ b/src/main/java/personal/llmapiclient/controller/LLMExampleController.java
@@ -1,0 +1,102 @@
+package personal.llmapiclient.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import personal.llmapiclient.client.LLMStreamingClient;
+import personal.llmapiclient.requestdto.RecipeOptionsRequest;
+import personal.llmapiclient.util.ResponseGenerator;
+import personal.llmapiclient.util.StreamingProcessor;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class LLMExampleController {
+    private final LLMStreamingClient llmStreamingClient;
+
+    @Value("${llm.recipe.template}")
+    private String template;
+
+    private static final String GET_RECIPE_LLM_STREAMING = "LLM API를 통해 레시피 정보를 조회하는 예시";
+    private static final String GET_RECIPE_LLM_STREAMING_DESCRIPTION
+            = "LLM API를 통해 레시피 정보를 조회할 수 있습니다.";
+
+    private static final String GET_RECIPE_LLM_SSE_STREAMING = "LLM API를 통해 SSE 방식으로 레시피 정보를 조회하는 예시";
+    private static final String GET_RECIPE_LLM_SSE_STREAMING_DESCRIPTION
+            = "LLM API를 통해 SSE 방식으로 레시피 정보를 조회할 수 있습니다.";
+
+    private static final String MEAL_TYPE = "식사 유형";
+    private static final String MEAL_TYPE_EXAMPLE = "아침";
+
+    private static final String CUISINETYPE = "요리 유형";
+    private static final String CUISINETYPE_EXAMPLE = "한식";
+
+    private static final String INGREDIENTS = "재료 목록";
+    private static final String INGREDIENTS_EXAMPLE = "된장, 파, 마늘";
+
+    private static final String COOKING_UTENSILS = "조리 도구";
+    private static final String COOKING_UTENSILS_EXAMPLE = "프라이팬, 냄비, 식칼";
+
+    private static final String COOKING_TIME = "조리 시간";
+    private static final String COOKING_TIME_EXAMPLE = "30분";
+
+    @ApiOperation(
+            value = GET_RECIPE_LLM_STREAMING, notes = GET_RECIPE_LLM_STREAMING_DESCRIPTION
+    )
+    @GetMapping(value = "/example", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestRecipeLLM(
+            @ApiParam(value = MEAL_TYPE, example = MEAL_TYPE_EXAMPLE)
+            @RequestParam String mealType,
+            @ApiParam(value = CUISINETYPE, example = CUISINETYPE_EXAMPLE)
+            @RequestParam String cuisineType,
+            @ApiParam(value = INGREDIENTS, defaultValue = INGREDIENTS_EXAMPLE)
+            @RequestParam List<String> ingredients,
+            @ApiParam(value = COOKING_UTENSILS, defaultValue = COOKING_UTENSILS_EXAMPLE)
+            @RequestParam List<String> cookingUtensils,
+            @ApiParam(value = COOKING_TIME, example = COOKING_TIME_EXAMPLE)
+            @RequestParam String cookingTime
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreaming(
+                RecipeOptionsRequest.of(mealType, cuisineType, ingredients, cookingUtensils, cookingTime), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+
+    @ApiOperation(
+            value = GET_RECIPE_LLM_SSE_STREAMING, notes = GET_RECIPE_LLM_SSE_STREAMING_DESCRIPTION
+    )
+    @GetMapping(value = "/example/sse", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestRecipeSSELLM(
+            @ApiParam(value = MEAL_TYPE, example = MEAL_TYPE_EXAMPLE)
+            @RequestParam String mealType,
+            @ApiParam(value = CUISINETYPE, example = CUISINETYPE_EXAMPLE)
+            @RequestParam String cuisineType,
+            @ApiParam(value = INGREDIENTS, defaultValue = INGREDIENTS_EXAMPLE)
+            @RequestParam List<String> ingredients,
+            @ApiParam(value = COOKING_UTENSILS, defaultValue = COOKING_UTENSILS_EXAMPLE)
+            @RequestParam List<String> cookingUtensils,
+            @ApiParam(value = COOKING_TIME, example = COOKING_TIME_EXAMPLE)
+            @RequestParam String cookingTime
+    ) {
+        Flux<String> responseFlux = llmStreamingClient.receiveLLMStreamingSSE(
+                RecipeOptionsRequest.of(mealType, cuisineType, ingredients, cookingUtensils, cookingTime), template
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+}

--- a/src/main/java/personal/llmapiclient/exception/ErrorResponse.java
+++ b/src/main/java/personal/llmapiclient/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package personal.llmapiclient.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ErrorResponse {
+    private int statusCode;
+    private String message;
+}

--- a/src/main/java/personal/llmapiclient/filtration/JwtAuthenticationFilter.java
+++ b/src/main/java/personal/llmapiclient/filtration/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package personal.llmapiclient.filtration;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import personal.llmapiclient.security.CustomAuthenticationEntryPoint;
+import personal.llmapiclient.security.JwtTokenProvider;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    @Override
+    protected void doFilterInternal
+            (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String ipAddress = request.getRemoteAddr();
+        log.info("Request IP Address: " + ipAddress);
+
+        String token = resolveTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            try {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info(String.format("[%s] -> %s", jwtTokenProvider.getUserId(token), request.getRequestURI()));
+            } catch (UsernameNotFoundException e) {
+                customAuthenticationEntryPoint.commence(request, response, e);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/personal/llmapiclient/interception/LoggingInterceptor.java
+++ b/src/main/java/personal/llmapiclient/interception/LoggingInterceptor.java
@@ -1,0 +1,47 @@
+package personal.llmapiclient.interception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerInterceptor;
+import personal.llmapiclient.util.PerformanceMeasurer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static personal.llmapiclient.util.LogConstant.PERFORMANCE_MEASUREMENT;
+
+public class LoggingInterceptor implements HandlerInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(LoggingInterceptor.class);
+    private static final String REQUEST_RECEPTION = "Received request for '{}'";
+    private static final String REQUEST_COMPLETION
+            = "Completed request for '{}', status code: {}, ";
+    private static final String BEFORE_MEMORY = "beforeMemory";
+    private static final String STARTED_AT = "startedAt";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        log.info(REQUEST_RECEPTION, request.getRequestURI());
+
+        long beforeMemory = PerformanceMeasurer.computeUsedMemory(0);
+        long startedAt = PerformanceMeasurer.computeElapsedTime(0);
+
+        request.setAttribute(BEFORE_MEMORY, beforeMemory);
+        request.setAttribute(STARTED_AT, startedAt);
+
+        return true;
+    }
+
+    @Override
+    public void afterCompletion
+            (HttpServletRequest request, HttpServletResponse response, Object handler, Exception e) {
+        long beforeMemory = (long) request.getAttribute(BEFORE_MEMORY);
+        long startedAt = (long) request.getAttribute(STARTED_AT);
+        long elapsedTime = PerformanceMeasurer.computeElapsedTime(startedAt);
+        long memoryUsage = PerformanceMeasurer.computeUsedMemory(beforeMemory);
+
+        log.info(
+                REQUEST_COMPLETION + PERFORMANCE_MEASUREMENT,
+                request.getRequestURI(), response.getStatus(), elapsedTime, memoryUsage
+        );
+    }
+}

--- a/src/main/java/personal/llmapiclient/requestdto/AbstractOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/AbstractOptionsRequest.java
@@ -1,0 +1,4 @@
+package personal.llmapiclient.requestdto;
+
+public abstract class AbstractOptionsRequest {
+}

--- a/src/main/java/personal/llmapiclient/requestdto/DefaultOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/DefaultOptionsRequest.java
@@ -1,0 +1,28 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class DefaultOptionsRequest extends AbstractOptionsRequest {
+    private List<String> option1;
+    private List<String> option2;
+    private List<String> option3;
+
+    @Builder
+    private DefaultOptionsRequest(List<String> option1, List<String> option2, List<String> option3) {
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+    }
+
+    public static DefaultOptionsRequest of(List<String> option1, List<String> option2, List<String> option3) {
+        return new DefaultOptionsRequest(option1, option2, option3);
+    }
+}

--- a/src/main/java/personal/llmapiclient/requestdto/LLMRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/LLMRequest.java
@@ -1,0 +1,24 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Getter;
+
+@Getter
+public class LLMRequest {
+    private String llm_type;
+    private String template;
+    private AbstractOptionsRequest options;
+    private String secret_key;
+
+    private LLMRequest(String llm_type, String template, AbstractOptionsRequest optionsRequest, String secret_key) {
+        this.llm_type = llm_type;
+        this.template = template;
+        options = optionsRequest;
+        this.secret_key = secret_key;
+    }
+
+    public static LLMRequest from(
+            String llm_type, String template, AbstractOptionsRequest optionsRequest, String secret_key
+    ) {
+        return new LLMRequest(llm_type, template, optionsRequest, secret_key);
+    }
+}

--- a/src/main/java/personal/llmapiclient/requestdto/RecipeOptionsRequest.java
+++ b/src/main/java/personal/llmapiclient/requestdto/RecipeOptionsRequest.java
@@ -1,0 +1,35 @@
+package personal.llmapiclient.requestdto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeOptionsRequest extends AbstractOptionsRequest {
+    private List<String> mealType;
+    private List<String> cuisineType;
+    private List<String> ingredients;
+    private List<String> cookingUtensils;
+    private List<String> cookingTime;
+
+
+    private RecipeOptionsRequest(
+            List<String> mealType, List<String> cuisineType, List<String> ingredients,
+            List<String> cookingUtensils, List<String> cookingTime
+    ) {
+        this.mealType = mealType;
+        this.cuisineType = cuisineType;
+        this.ingredients = ingredients;
+        this.cookingUtensils = cookingUtensils;
+        this.cookingTime = cookingTime;
+    }
+
+    public static RecipeOptionsRequest of(
+            String mealType, String cuisineType, List<String> ingredients,
+            List<String> cookingUtensils, String cookingTime
+    ) {
+        return new RecipeOptionsRequest(
+                List.of(mealType), List.of(cuisineType), ingredients, cookingUtensils, List.of(cookingTime)
+        );
+    }
+}

--- a/src/main/java/personal/llmapiclient/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/personal/llmapiclient/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,51 @@
+package personal.llmapiclient.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import personal.llmapiclient.exception.ErrorResponse;
+import personal.llmapiclient.util.LogConstant;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger log = LoggerFactory.getLogger(CustomAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException e) throws IOException {
+        ErrorResponse errorResponse;
+
+        if (e instanceof UsernameNotFoundException) {
+            log.warn(LogConstant.LOG_WARN_MESSAGE, e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_UNAUTHORIZED)
+                    .message(e.getMessage())
+                    .build();
+        } else {
+            log.error(LogConstant.LOG_ERROR_MESSAGE, e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_FORBIDDEN)
+                    .message(e.getMessage())
+                    .build();
+        }
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.flushBuffer();
+    }
+}

--- a/src/main/java/personal/llmapiclient/security/JwtTokenProvider.java
+++ b/src/main/java/personal/llmapiclient/security/JwtTokenProvider.java
@@ -1,0 +1,95 @@
+package personal.llmapiclient.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    private static final String KEY_ROLES = "roles";
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 2;
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7;
+    private final UserDetailsService userDetailsService;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    @PostConstruct
+    public void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String generateAccessToken(String userId, List<String> roles) {
+
+        Claims claims = Jwts.claims().setSubject(userId);
+        claims.put(KEY_ROLES, roles);
+
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(String userId, List<String> roles) {
+
+        Claims claims = Jwts.claims().setSubject(userId);
+        claims.put(KEY_ROLES, roles);
+
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUserId(token));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return !claims.getExpiration().before(new Date());
+    }
+
+    public String getUserId(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/personal/llmapiclient/util/LogConstant.java
+++ b/src/main/java/personal/llmapiclient/util/LogConstant.java
@@ -1,0 +1,8 @@
+package personal.llmapiclient.util;
+
+public class LogConstant {
+    public static final String PERFORMANCE_MEASUREMENT = "estimated time: {} ms, used memory: {} bytes";
+
+    public static final String LOG_ERROR_MESSAGE = "Error exception occurred: {}";
+    public static final String LOG_WARN_MESSAGE = "Warning exception occurred: {}";
+}

--- a/src/main/java/personal/llmapiclient/util/PerformanceMeasurer.java
+++ b/src/main/java/personal/llmapiclient/util/PerformanceMeasurer.java
@@ -1,0 +1,13 @@
+package personal.llmapiclient.util;
+
+public class PerformanceMeasurer {
+    private static final Runtime RUNTIME = Runtime.getRuntime();
+
+    public static long computeElapsedTime(long startedAt) {
+        return System.currentTimeMillis() - startedAt;
+    }
+
+    public static long computeUsedMemory(long beforeMemory) {
+        return RUNTIME.totalMemory() - RUNTIME.freeMemory() - beforeMemory;
+    }
+}

--- a/src/main/java/personal/llmapiclient/util/RequestConstant.java
+++ b/src/main/java/personal/llmapiclient/util/RequestConstant.java
@@ -1,0 +1,7 @@
+package personal.llmapiclient.util;
+
+public class RequestConstant {
+    public static final String JWT = "JWT";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String HEADER = "header";
+}

--- a/src/main/java/personal/llmapiclient/util/ResponseGenerator.java
+++ b/src/main/java/personal/llmapiclient/util/ResponseGenerator.java
@@ -1,0 +1,13 @@
+package personal.llmapiclient.util;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+
+public class ResponseGenerator {
+    public static ResponseEntity<Flux<String>> generateResponse(Flux<String> responseFlux) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(responseFlux.flatMap(chunk -> Flux.just(chunk + "\n\n")));
+    }
+}

--- a/src/main/java/personal/llmapiclient/util/StreamingProcessor.java
+++ b/src/main/java/personal/llmapiclient/util/StreamingProcessor.java
@@ -1,0 +1,24 @@
+package personal.llmapiclient.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StreamingProcessor {
+    private static final Logger log = LoggerFactory.getLogger(StreamingProcessor.class);
+
+    public static void proceedStreaming(Flux<String> responseFlux) {
+        AtomicInteger counter = new AtomicInteger(0);
+        responseFlux.subscribe(
+                chunk -> {
+                    if (counter.incrementAndGet() % 10 == 0) {
+                        log.info("Received chunk: {}", chunk);
+                    }
+                },
+                error -> log.error(LogConstant.LOG_ERROR_MESSAGE, error.getMessage(), error),
+                () -> log.info("Streaming finished.")
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,45 @@
+server:
+  url: ${LLM_API_CLIENT_IP}
+  port: 443
+  ssl:
+    key-store: file:/app/keystore.p12
+    key-store-password: ${SSL_KEY_STORE_PASSWORD}
+    keyStoreType: PKCS12
+    keyAlias: tomcat
+spring:
+  application:
+    name: llm-api-client
+  mvc:
+    pathmatch:
+      matching-strategy: ANT_PATH_MATCHER
+    view:
+      prefix: /
+      suffix: .html
+  jackson:
+    date-format: yyyy-MM-dd HH:mm:ss
+    time-zone: Asia/Seoul
+    serialization:
+      fail-on-empty-beans: false
+jwt:
+  secret:
+    key: ${LLM_API_CLIENT_JWT_SECRET_KEY}
+llm:
+  server:
+    secret-key: ${SECRET_KEY}
+    endpoint:
+      streaming: ${LLM_SERVER_STREAMING_ENDPOINT}
+      sse: /${LLM_SERVER_SSE_ENDPOINT}
+  type: ${LLM_TYPE}
+  template: ${LLM_TEMPLATE}
+  recipe:
+    template: ${LLM_RECIPE_TEMPLATE}
+frontend:
+  url: ${FRONTEND_URL}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,8 @@ spring:
     time-zone: Asia/Seoul
     serialization:
       fail-on-empty-beans: false
+logging:
+  config: classpath:logback-spring.xml
 jwt:
   secret:
     key: ${LLM_API_CLIENT_JWT_SECRET_KEY}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <property name="LOGS_PATH" value="./logs"/>
+    <property name="LOGS_LEVEL" value="INFO"/>
+
+    <!--Console Appender-->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{HH:mm} %-5level %logger{36} - %msg%n</pattern>
+        </layout>
+    </appender>
+
+    <!--file appender-->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS_PATH}/log_file.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- error appender-->
+    <appender name="Error" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS_PATH}/error_file.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_error.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="${LOGS_LEVEL}">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="Error"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## partially resolve [LSAC-1](https://langchain.atlassian.net/browse/LSAC-1)
## resolve #12

## 릴리스 정보 - LLM Streaming API Client - LlmStreamingApiClientRelease02/02

### 하위 작업

[LSAC-3](https://langchain.atlassian.net/browse/LSAC-3) gradle 의존성 추가

[LSAC-4](https://langchain.atlassian.net/browse/LSAC-4) production application 설정 추가

[LSAC-5](https://langchain.atlassian.net/browse/LSAC-5) production application 클래스 추가

[LSAC-6](https://langchain.atlassian.net/browse/LSAC-6) gitignore 추가

[LSAC-8](https://langchain.atlassian.net/browse/LSAC-8) 로깅 설정 파일 추가

[LSAC-9](https://langchain.atlassian.net/browse/LSAC-9) LoggingInterceptor 추가

[LSAC-10](https://langchain.atlassian.net/browse/LSAC-10) LoggingAspect 추가

[LSAC-12](https://langchain.atlassian.net/browse/LSAC-12) 인증을 위한 필터 설정

[LSAC-13](https://langchain.atlassian.net/browse/LSAC-13) JWT 토큰 설정

[LSAC-14](https://langchain.atlassian.net/browse/LSAC-14) 인증 없이 요청 가능한 엔드포인트 허용 설정

[LSAC-15](https://langchain.atlassian.net/browse/LSAC-15) 특정 출처에 대한 CORS 활성화

[LSAC-17](https://langchain.atlassian.net/browse/LSAC-17) springfox 의존성 추가

[LSAC-18](https://langchain.atlassian.net/browse/LSAC-18) Swagger 설정 추가

[LSAC-20](https://langchain.atlassian.net/browse/LSAC-20) 기존에 구현한 LLM Streaming 서버로 Prompt 요청을 전송해 응답을 제공받는 클라이언트 컴포넌트 추가

[LSAC-21](https://langchain.atlassian.net/browse/LSAC-21) 특정 Prompt에 대한 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가

[LSAC-22](https://langchain.atlassian.net/browse/LSAC-22) 특정 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 템플릿 엔드포인트 추가

[LSAC-23](https://langchain.atlassian.net/browse/LSAC-23) 레시피 추천 요청 Prompt에 대한 Steraming 응답을 제공받을 수 있는 예시 엔드포인트 추가

[LSAC-24](https://langchain.atlassian.net/browse/LSAC-24) 레시피 추천 요청 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 레시피 추천 예시 엔드포인트 추가

### 에픽

[LSAC-1](https://langchain.atlassian.net/browse/LSAC-1) LLM API 클라이언트 서버 템플릿 구현

### 스토리

[LSAC-19](https://langchain.atlassian.net/browse/LSAC-19) 클라이언트는 서버로부터 개발 서비스 도메인에 대한 LLM 스트리밍 서비스를 제공받을 수 있다

### 작업

[LSAC-2](https://langchain.atlassian.net/browse/LSAC-2) 프로젝트 환경 설정

[LSAC-7](https://langchain.atlassian.net/browse/LSAC-7) 전체 프로젝트의 로깅 프로세스 추가

[LSAC-11](https://langchain.atlassian.net/browse/LSAC-11) Spring Security 설정 추가

[LSAC-16](https://langchain.atlassian.net/browse/LSAC-16) 서버 API 문서화를 위한 Swagger 추가

[LSAC-25](https://langchain.atlassian.net/browse/LSAC-25) README.md 추가